### PR TITLE
Make this load on ultramine

### DIFF
--- a/src/main/java/mods/natura/Natura.java
+++ b/src/main/java/mods/natura/Natura.java
@@ -49,7 +49,7 @@ import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.world.ChunkDataEvent;
 import net.minecraftforge.oredict.OreDictionary;
 
-@Mod(modid = "Natura", name = "Natura", version = "GRADLETOKEN_VERSION", acceptedMinecraftVersions = "[1.7.10]", dependencies = "required-after:Mantle")
+@Mod(modid = "Natura", name = "Natura", version = "GRADLETOKEN_VERSION", acceptedMinecraftVersions = "[1.7.10]", dependencies = "required-after:Mantle;after:TConstruct")
 public class Natura {
     /* Proxies for sides, used for graphics processing */
     @SidedProxy(clientSide = "mods.natura.client.NProxyClient", serverSide = "mods.natura.common.NProxyCommon")


### PR DESCRIPTION
According to https://discord.com/channels/181078474394566657/305737190195986433/921153220464738304 natura natura need to be loaded after tconstruct to make ultramine work.

The source of dependency occurs in NContent.java, but it looks pretty innocent, and should run late enough that classes are present on classpath already. UltraMine might be doing some very aggressive optimization, e.g. preemptive class loading, parallel initialization or whatever. For now we are good with this minor tweak.