### PR TITLE
Add proper names to Natura's fences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /run/
 /build/
 /eclipse/
+.vscode
 .classpath
 .project
 /bin/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: ffe7b130f98fdfa1ac7c6ba4bd34722a55ab28d4
+//version: 8fa7883b6196c1765266f4e6ddf3118d5043aafb
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -42,6 +42,7 @@ plugins {
     id("org.ajoberstar.grgit") version("3.1.1")
     id("com.github.johnrengelman.shadow") version("4.0.4")
     id("com.palantir.git-version") version("0.12.3")
+    id("maven-publish")
 }
 
 apply plugin: 'forge'
@@ -87,33 +88,27 @@ checkPropertyExists("containsMixinsAndOrCoreModOnly")
 checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
-def checkPropertyExists(String propertyName) {
-    if (project.hasProperty(propertyName) == false) {
-        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/gradle.properties")
-    }
-}
-
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
 
 String targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/")
 String targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/")
-if((new File(targetPackageJava).exists() || new File(targetPackageScala).exists()) == false) {
+if((getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists()) == false) {
     throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala)
 }
 
 if(apiPackage) {
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    if((new File(targetPackageJava).exists() || new File(targetPackageScala).exists()) == false) {
+    if((getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists()) == false) {
         throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala)
     }
 }
 
 if(accessTransformersFile) {
     String targetFile = "src/main/resources/META-INF/" + accessTransformersFile
-    if(new File(targetFile).exists() == false) {
+    if(getFile(targetFile).exists() == false) {
         throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
     }
 }
@@ -125,14 +120,14 @@ if(usesMixins.toBoolean()) {
 
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    if((new File(targetPackageJava).exists() || new File(targetPackageScala).exists()) == false) {
+    if((getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists()) == false) {
         throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala)
     }
 
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
-    if((new File(targetFileJava).exists() || new File(targetFileScala).exists() || new File(targetFileScalaJava).exists()) == false) {
+    if((getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists()) == false) {
         throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava)
     }
 }
@@ -141,7 +136,7 @@ if(coreModClass) {
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
-    if((new File(targetFileJava).exists() || new File(targetFileScala).exists() || new File(targetFileScalaJava).exists()) == false) {
+    if((getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists()) == false) {
         throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava)
     }
 }
@@ -163,8 +158,14 @@ try {
 catch (Exception e) {
     throw new IllegalStateException("This mod must be version controlled by Git AND the repository must provide at least one tag!");
 }
+
 group = modGroup
-archivesBaseName = modId
+if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
+    archivesBaseName = customArchiveBaseName
+}
+else {
+    archivesBaseName = modId
+}
 
 minecraft {
     version = minecraftVersion + "-" + forgeVersion + "-" + minecraftVersion
@@ -194,7 +195,9 @@ if(file("addon.gradle").exists()) {
 apply from: 'repositories.gradle'
 
 configurations {
-    implementation.extendsFrom(shadowImplementation)
+    implementation.extendsFrom(shadowImplementation)  // TODO: remove after all uses are refactored
+    implementation.extendsFrom(shadowCompile)
+    implementation.extendsFrom(shadeCompile)
 }
 
 repositories {
@@ -240,7 +243,7 @@ def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
     if(usesMixins.toBoolean()) {
-        new File(projectDir.toString() + "/src/main/resources/", "mixins." + modId + ".json").text = """{
+        getFile("/src/main/resources/mixins." + modId + ".json").text = """{
   "required": true,
   "minVersion": "0.7.11",
   "package": "${modGroup}.${mixinsPackage}",
@@ -260,16 +263,28 @@ task relocateShadowJar(type: ConfigureShadowRelocation) {
 }
 
 shadowJar {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
     manifest {
         attributes(getManifestAttributes())
     }
 
     minimize()  // This will only allow shading for actually used classes
-    configurations = [project.configurations.shadowImplementation]
+    configurations = [project.configurations.shadowImplementation, project.configurations.shadowCompile]
     dependsOn(relocateShadowJar)
 }
 
 jar {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
     manifest {
         attributes(getManifestAttributes())
     }
@@ -343,31 +358,31 @@ tasks.withType(JavaExec).configureEach {
 }
 
 processResources
-        {
-            // this will ensure that this task is redone when the versions change.
-            inputs.property "version", project.version
-            inputs.property "mcversion", project.minecraft.version
+{
+    // this will ensure that this task is redone when the versions change.
+    inputs.property "version", project.version
+    inputs.property "mcversion", project.minecraft.version
 
-            // replace stuff in mcmod.info, nothing else
-            from(sourceSets.main.resources.srcDirs) {
-                include 'mcmod.info'
+    // replace stuff in mcmod.info, nothing else
+    from(sourceSets.main.resources.srcDirs) {
+        include 'mcmod.info'
 
-                // replace version and mcversion
-                expand "minecraftVersion": project.minecraft.version,
-                        "modVersion": versionDetails().lastTag,
-                        "modId": modId,
-                        "modName": modName
-            }
+        // replace version and mcversion
+        expand "minecraftVersion": project.minecraft.version,
+                "modVersion": versionDetails().lastTag,
+                "modId": modId,
+                "modName": modName
+    }
 
-            if(usesMixins.toBoolean()) {
-                from refMap
-            }
+    if(usesMixins.toBoolean()) {
+        from refMap
+    }
 
-            // copy everything else, thats not the mcmod.info
-            from(sourceSets.main.resources.srcDirs) {
-                exclude 'mcmod.info'
-            }
-        }
+    // copy everything else, thats not the mcmod.info
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'mcmod.info'
+    }
+}
 
 def getManifestAttributes() {
     def manifestAttributes = [:]
@@ -400,6 +415,12 @@ task sourcesJar(type: Jar) {
 }
 
 task shadowDevJar(type: ShadowJar) {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
     from sourceSets.main.output
     getArchiveClassifier().set("dev")
 
@@ -408,7 +429,7 @@ task shadowDevJar(type: ShadowJar) {
     }
 
     minimize()  // This will only allow shading for actually used classes
-    configurations = [project.configurations.shadowImplementation]
+    configurations = [project.configurations.shadowImplementation, project.configurations.shadowCompile]
 }
 
 task relocateShadowDevJar(type: ConfigureShadowRelocation) {
@@ -423,6 +444,12 @@ task circularResolverJar(type: Jar) {
 }
 
 task devJar(type: Jar) {
+    project.configurations.shadeCompile.each { dep ->
+        from(project.zipTree(dep)) {
+            exclude 'META-INF', 'META-INF/**'
+        }
+    }
+
     from sourceSets.main.output
     getArchiveClassifier().set("dev")
 
@@ -438,11 +465,11 @@ task devJar(type: Jar) {
 
 task apiJar(type: Jar) {
     from (sourceSets.main.allJava) {
-        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString() + '/**'
+        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
     from (sourceSets.main.output) {
-        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString() + '/**'
+        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
     from (sourceSets.main.resources.srcDirs) {
@@ -460,18 +487,50 @@ artifacts {
     }
 }
 
+// publishing
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact source: jar
+            artifact source: sourcesJar, classifier: "src"
+            artifact source: devJar, classifier: "dev"
+            if (apiPackage) {
+                artifact source: apiJar, classifier: "api"
+            }
+
+            groupId = System.getenv("ARTIFACT_GROUP_ID") ?: group
+            artifactId = System.getenv("ARTIFACT_ID") ?: project.name
+            version = System.getenv("ARTIFACT_VERSION") ?: project.version
+        }
+    }
+    
+    repositories {
+        maven {
+            String owner = System.getenv("REPOSITORY_OWNER") ?: "Unknown"
+            String repositoryName = System.getenv("REPOSITORY_NAME") ?: "Unknown"
+            String githubRepositoryUrl = "https://maven.pkg.github.com/$owner/$repositoryName"
+            name = "GitHubPackages"
+            url = githubRepositoryUrl
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: "NONE"
+                password = System.getenv("GITHUB_TOKEN") ?: "NONE"
+            }
+        }
+    }
+}
+
 // Updating
 task updateBuildScript {
     doLast {
-        if (updateBuildScript()) return
+        if (performBuildScriptUpdate(projectDir.toString())) return
 
         print("Build script already up-to-date!")
     }
 }
 
-if (isNewBuildScriptVersionAvailable()) {
+if (isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
-        updateBuildScript()
+        performBuildScriptUpdate(projectDir.toString())
     } else {
         println("Build script update available! Run 'gradle updateBuildScript'")
     }
@@ -481,9 +540,9 @@ static URL availableBuildScriptUrl() {
     new URL("https://raw.githubusercontent.com/SinTh0r4s/ExampleMod1.7.10/main/build.gradle")
 }
 
-static boolean updateBuildScript() {
-    if (isNewBuildScriptVersionAvailable()) {
-        def buildscriptFile = new File("build.gradle")
+boolean performBuildScriptUpdate(String projectDir) {
+    if (isNewBuildScriptVersionAvailable(projectDir)) {
+        def buildscriptFile = getFile("build.gradle")
         availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
         print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
         return true
@@ -491,10 +550,10 @@ static boolean updateBuildScript() {
     return false
 }
 
-static boolean isNewBuildScriptVersionAvailable() {
+boolean isNewBuildScriptVersionAvailable(String projectDir) {
     Map parameters = ["connectTimeout": 2000, "readTimeout": 2000]
 
-    String currentBuildScript = new File("build.gradle").getText()
+    String currentBuildScript = getFile("build.gradle").getText()
     String currentBuildScriptHash = getVersionHash(currentBuildScript)
     String availableBuildScript = availableBuildScriptUrl().newInputStream(parameters).getText()
     String availableBuildScriptHash = getVersionHash(availableBuildScript)
@@ -514,4 +573,16 @@ static String getVersionHash(String buildScriptContent) {
 configure(updateBuildScript) {
     group = 'forgegradle'
     description = 'Updates the build script to the latest version'
+}
+
+// Helper methods
+
+def checkPropertyExists(String propertyName) {
+    if (project.hasProperty(propertyName) == false) {
+        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/SinTh0r4s/ExampleMod1.7.10/blob/main/gradle.properties")
+    }
+}
+
+def getFile(String relativePath) {
+    return new File(projectDir, relativePath)
 }

--- a/src/main/java/mods/natura/items/blocks/FenceItem.java
+++ b/src/main/java/mods/natura/items/blocks/FenceItem.java
@@ -2,16 +2,16 @@ package mods.natura.items.blocks;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mantle.blocks.abstracts.MultiItemBlock;
 import mods.natura.common.NContent;
 import net.minecraft.block.Block;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.util.IIcon;
 
-public class FenceItem extends ItemBlock
+public class FenceItem extends MultiItemBlock
 {
-    public FenceItem(Block i)
+    public FenceItem(Block block)
     {
-        super(i);
+        super(block, block.getUnlocalizedName(), NContent.woodTextureNames);
         setMaxDamage(0);
         setHasSubtypes(true);
     }

--- a/src/main/resources/assets/natura/lang/en_US.lang
+++ b/src/main/resources/assets/natura/lang/en_US.lang
@@ -151,6 +151,20 @@ tile.pressureplate.maple.name=Maple Pressure Plate
 tile.pressureplate.amaranth.name=Amaranth Pressure Plate
 tile.pressureplate.silverbell.name=Silverbell Pressure Plate
 
+tile.fence.eucalyptus.name=Eucalyptus Fence
+tile.fence.sakura.name=Sakura Fence
+tile.fence.ghostwood.name=Ghostwood Fence
+tile.fence.hopseed.name=Hopseed Fence
+tile.fence.redwood.name=Redwood Fence
+tile.fence.bloodwood.name=Blood Fence
+tile.fence.darkwood.name=Darkwood Fence
+tile.fence.fusewood.name=Fusewood Fence
+tile.fence.willow.name=Willow Fence
+tile.fence.tiger.name=Tigerwood Fence
+tile.fence.maple.name=Maple Fence
+tile.fence.purpleheart.name=Amaranth Fence
+tile.fence.silverbell.name=Silverbell Fence
+
 tile.fenceGate.eucalyptus.name=Eucalyptus Fence Gate
 tile.fenceGate.sakura.name=Sakura Fence Gate
 tile.fenceGate.ghostwood.name=Ghostwood Fence Gate


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#6811.

Doesn't look like it affects their use in recipes. Harmonizes fence naming conventions with Forestry and Extra Trees.

Example of selecting 1 fence in inventory while looking at another :
![image](https://user-images.githubusercontent.com/5321549/147830233-d48997e0-3c29-4f95-907a-cc4fe73bf403.png)