### PR TITLE
fix mass recipe removal and collisions

### DIFF
--- a/src/main/java/mods/natura/common/NContent.java
+++ b/src/main/java/mods/natura/common/NContent.java
@@ -1722,7 +1722,8 @@ public class NContent implements IFuelHandler {
         OreDictionary.registerOre("logWood", new ItemStack(tree, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("logWood", new ItemStack(redwood, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("logWood", new ItemStack(willow, 1, OreDictionary.WILDCARD_VALUE));
-        OreDictionary.registerOre("logWood", new ItemStack(bloodwood, 1, OreDictionary.WILDCARD_VALUE));
+        OreDictionary.registerOre("logWood", new ItemStack(bloodwood, 1, 0));
+        OreDictionary.registerOre("logWood", new ItemStack(bloodwood, 1, 15));
         OreDictionary.registerOre("logWood", new ItemStack(rareTree, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("logWood", new ItemStack(darkTree, 1, OreDictionary.WILDCARD_VALUE));
 


### PR DESCRIPTION
fixes 90k crafting recipe removals and 32k machine recipe collisions caused by https://github.com/GTNewHorizons/GT5-Unofficial/pull/2641

I dont really understand why bloodwood is such a problem though, only that this fixes it.

:0 is the normal one, :15 closed on all sides