### PR TITLE
don't oredict nether woods if extratic is active to avoid breaking compatibility

### DIFF
--- a/src/main/java/mods/natura/common/NContent.java
+++ b/src/main/java/mods/natura/common/NContent.java
@@ -1734,7 +1734,20 @@ public class NContent implements IFuelHandler {
         OreDictionary.registerOre("treeLeaves", new ItemStack(darkLeaves, 1, OreDictionary.WILDCARD_VALUE));
 
         // Wooden Planks
-        OreDictionary.registerOre("plankWood", new ItemStack(planks, 1, OreDictionary.WILDCARD_VALUE));
+
+        if (!Loader.isModLoaded("ExtraTiC")) {
+            // Wooden Planks
+            OreDictionary.registerOre("plankWood", new ItemStack(planks, 1, OreDictionary.WILDCARD_VALUE));
+
+            // Wooden Sticks
+            OreDictionary.registerOre("stickWood", new ItemStack(stickItem, 1, OreDictionary.WILDCARD_VALUE));
+        } else {
+            int[] toRegister = { 0, 1, 3, 5, 6, 7, 8, 9, 10 };
+            for (int i : toRegister) {
+                OreDictionary.registerOre("plankWood", new ItemStack(planks, 1, i));
+                OreDictionary.registerOre("stickWood", new ItemStack(stickItem, 1, i));
+            }
+        }
 
         // Wooden Workbenches
         if (PHNatura.enableWoodenWorkbenches) {
@@ -1900,9 +1913,6 @@ public class NContent implements IFuelHandler {
 
         // Nether items
         OreDictionary.registerOre("bowlWood", new ItemStack(bowlEmpty, 1, 0));
-
-        // Wooden Sticks
-        OreDictionary.registerOre("stickWood", new ItemStack(stickItem, 1, OreDictionary.WILDCARD_VALUE));
     }
 
     public void createEntities() {


### PR DESCRIPTION
If the nether woods are oredicted to plankWood/stickWood, they won't be properly usable as tinker's materials due to them defaulting to regular wood instead of the nether equivalent.