### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/natura/lang/en_US.lang
+++ b/src/main/resources/assets/natura/lang/en_US.lang
@@ -10,6 +10,7 @@ item.wartBag.name=Nether Wart Bag
 item.cottonBag.name=Cotton Seed Bag
 item.boneBag.name=Bonemeal Bag
 
+item.barleyFood.name=Resource
 item.barley.seed.name=Barley Seeds
 item.barley.plant.name=Barley
 item.barley.flour.name=Barley Flour
@@ -25,56 +26,70 @@ item.powder.sulfur.name=Sulfur
 item.waterdrop.name=Cactus Juice
 item.saguaro.fruit.name=Saguaro Fruit
 
+item.berry.name=Berry
 item.berry.rasp.name=Raspberry
 item.berry.blue.name=Blueberry
 item.berry.black.name=Blackberry
 item.berry.geo.name=Maloberry
+item.berryMedley.name=Berry Medley
 item.berry.medley.name=Berry Medley
+item.berry.nether.name=Nether Berry
 item.berry.blight.name=Blightberry
 item.berry.dusk.name=Duskberry
 item.berry.sky.name=Skyberry
 item.berry.sting.name=Stingberry
 
+tile.berrybush.name=Berry Bush
 block.rasp.berryBush.name=Raspberry Bush
 block.blue.berryBush.name=Blueberry Bush
 block.black.berryBush.name=Blackberry Bush
 block.geo.berryBush.name=Maloberry Bush
 
+tile.berrybush.name=Nether Berry Bush
 block.bush.berry.blight.name=Blightberry Bush
 block.bush.berry.dusk.name=Duskberry Bush
 block.bush.berry.sky.name=Skyberry Bush
 block.bush.berry.sting.name=Stingberry Bush
 
+tile.RareTree.name=Wood
 block.log.maple.name=Maple Wood
 block.log.silverbell.name=Silverbell Wood
 block.log.purpleheart.name=Amaranth Wood
 block.log.tiger.name=Tiger Wood
 block.log.willow.name=Willow Wood
 
+tile.Darktree.name=Wood
 block.log.darkwood.name=Darkwood
 block.log.fusewood.name=Fusewood
 
+item.natura.emptybowl.name=Bowl
+item.natura.stewbowl.name=Stew
 item.bowl.mushroom.name=Mushroom Stew
 item.bowl.glowshroom.name=Glowshroom Stew
 
+tile.Darkleaves.name=Leaves
 block.leaves.darkwood.name=Darkwood Leaves
 block.leaves.darkwood.flowering.name=Darkwood Leaves
 block.leaves.darkwood.fruit.name=Darkwood Leaves
 block.leaves.fusewood.name=Fusewood Leaves
 
+item.Natura.netherfood.name=Potash Apple
 item.food.nether.potashapple.name=Potash Apple
 
+tile.RareLeaves.name=Leaves
 block.leaves.maple.name=Maple Leaves
 block.leaves.silverbell.name=Silverbell Leaves
 block.leaves.purpleheart.name=Amaranth Leaves
 block.leaves.tiger.name=Tiger Leaves
 block.leaves.willow.name=Willow Leaves
 
+tile.cloud.name=Cloud
 block.normal.cloud.name=Cloud
 block.dark.cloud.name=Dark Cloud
 block.ash.cloud.name=Ash Cloud
 block.sulfur.cloud.name=Sulfur Cloud
 
+item.redwoodDoorItem.name=Door
 redwoodNDoor.name=Redwood Door
 eucalyptusNDoor.name=Eucalyptus Door
 hopseedNDoor.name=Hopseed Door
@@ -83,10 +98,12 @@ ghostNDoor.name=Ghostwood Door
 bloodNDoor.name=Bloodwood Door
 redwoodBarkNDoor.name=Redwood Bark Door
 
+tile.natura.redwood.name=Redwood
 block.bark.redwood.name=Redwood Bark
 block.heart.redwood.name=Redwood
 block.root.redwood.name=Redwood Root
 
+tile.natura.planks.name=Planks
 block.eucalyptus.NPlanks.name=Eucalyptus Planks
 block.sakura.NPlanks.name=Sakura Planks
 block.ghost.NPlanks.name=Ghostwood Planks
@@ -101,6 +118,8 @@ block.willow.NPlanks.name=Willow Planks
 block.darkwood.NPlanks.name=Darkwood Planks
 block.fusewood.NPlanks.name=Fusewood Planks
 
+tile.natura.sapling.name=Sapling
+tile.RareSapling.name=Sapling
 block.sapling.eucalyptus.name=Eucalyptus Sapling
 block.sapling.sakura.name=Sakura Sapling
 block.sapling.ghost.name=Ghostwood Sapling
@@ -115,6 +134,8 @@ block.sapling.maple.name=Maple Sapling
 block.sapling.purpleheart.name=Amaranth Sapling
 block.sapling.silverbell.name=Silverbell Sapling
 
+tile.plankSlab1.name=Slab
+tile.plankSlab2.name=Slab
 block.wood.eucalyptus.slab.name=Eucalyptus Slab
 block.wood.sakura.slab.name=Sakura Slab
 block.wood.ghost.slab.name=Ghostwood Slab
@@ -230,13 +251,17 @@ tile.furnace.netherrack.name=Nether Furnace
 tile.nether.obelisk.name=Obelisk
 tile.nether.hopper.name=Hopper
 
+tile.nether.glass.name=Nether Glass
 tile.glass.soul.name=Soul Glass
 tile.glass.heat.name=Heat Glass
 
+tile.Glowshroom.name=Glowshroom
 block.glowshroom.green.name=Green Glowshroom
 block.glowshroom.purple.name=Purple Glowshroom
 block.glowshroom.blue.name=Blue Glowshroom
 
+tile.natura.leaves.name=Leaves
+tile.natura.leavesnocolor.name=Leaves
 block.eucalyptus.NLeaves.name=Eucalyptus Leaves
 block.leaves.sakura.name=Sakura Leaves
 block.leaves.ghost.name=Ghostwood Leaves
@@ -244,6 +269,7 @@ block.bush.NLeaves.name=Hopseed Leaves
 block.redwood.NLeaves.name=Redwood Leaves
 block.leaves.blood.name=Bloodleaves
 
+tile.natura.treeblock.name=Wood
 block.eucalyptus.log.name=Eucalyptus Wood
 block.sakura.log.name=Sakura Wood
 block.ghost.log.name=Ghostwood
@@ -254,12 +280,15 @@ bloodBoat.name=Bloodwood Boat
 whiteBoat.name=White Boat
 eucalyptusBoat.name=Eucalyptus Boat
 
+item.impmeat.name=Imphide
 item.impmeat.raw.name=Raw Imphide
 item.impmeat.cooked.name=Cooked Imphide
 
+tile.GrassBlock.name=Grass
 block.soil.grass.name=Topiary Grass
 block.soil.bluegrass.name=Bluegrass
 block.soil.autumngrass.name=Autumnal Grass
+tile.GrassSlab.name=Grass Slab
 block.soil.grass.slab.name=Topiary Grass Slab
 block.soil.bluegrass.slab.name=Bluegrass Slab
 block.soil.autumngrass.slab.name=Autumnal Grass Slab


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.