### PR TITLE
use mc fuel calculation to fix issue with some fuels not being picked up

### DIFF
--- a/src/main/java/mods/natura/blocks/tech/NetherrackFurnaceLogic.java
+++ b/src/main/java/mods/natura/blocks/tech/NetherrackFurnaceLogic.java
@@ -1,17 +1,8 @@
 package mods.natura.blocks.tech;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockLog;
-import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemHoe;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemSword;
-import net.minecraft.item.ItemTool;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -21,10 +12,8 @@ import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.MathHelper;
 
-import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import mantle.blocks.BlockUtils;
 
 public class NetherrackFurnaceLogic extends TileEntityFurnace {
 
@@ -270,7 +259,8 @@ public class NetherrackFurnaceLogic extends TileEntityFurnace {
 
         if (!this.worldObj.isRemote) {
             if (this.furnaceBurnTime == 0 && this.canSmelt()) {
-                this.currentItemBurnTime = this.furnaceBurnTime = TileEntityFurnace.getItemBurnTime(this.inventory[1]) * 2;
+                this.currentItemBurnTime = this.furnaceBurnTime = TileEntityFurnace.getItemBurnTime(this.inventory[1])
+                        * 2;
 
                 if (this.furnaceBurnTime > 0) {
                     flag1 = true;

--- a/src/main/java/mods/natura/blocks/tech/NetherrackFurnaceLogic.java
+++ b/src/main/java/mods/natura/blocks/tech/NetherrackFurnaceLogic.java
@@ -154,7 +154,7 @@ public class NetherrackFurnaceLogic extends TileEntityFurnace {
 
         this.furnaceBurnTime = par1NBTTagCompound.getShort("BurnTime");
         this.furnaceCookTime = par1NBTTagCompound.getShort("CookTime");
-        this.currentItemBurnTime = getFuelTime(this.inventory[1]) * 2;
+        this.currentItemBurnTime = TileEntityFurnace.getItemBurnTime(this.inventory[1]) * 2;
 
         if (par1NBTTagCompound.hasKey("CustomName")) {
             this.field_94130_e = par1NBTTagCompound.getString("CustomName");
@@ -270,7 +270,7 @@ public class NetherrackFurnaceLogic extends TileEntityFurnace {
 
         if (!this.worldObj.isRemote) {
             if (this.furnaceBurnTime == 0 && this.canSmelt()) {
-                this.currentItemBurnTime = this.furnaceBurnTime = getFuelTime(this.inventory[1]) * 2;
+                this.currentItemBurnTime = this.furnaceBurnTime = TileEntityFurnace.getItemBurnTime(this.inventory[1]) * 2;
 
                 if (this.furnaceBurnTime > 0) {
                     flag1 = true;
@@ -358,52 +358,10 @@ public class NetherrackFurnaceLogic extends TileEntityFurnace {
     }
 
     /**
-     * Returns the number of ticks that the supplied fuel item will keep the furnace burning, or 0 if the item isn't
-     * fuel
-     */
-    public static int getFuelTime(ItemStack par0ItemStack) {
-        if (par0ItemStack == null) {
-            return 0;
-        } else {
-            Item item = par0ItemStack.getItem();
-
-            if (par0ItemStack.getItem() instanceof ItemBlock && item != null) {
-                Block block = BlockUtils.getBlockFromItem(item);
-
-                if (block == Blocks.wooden_slab) {
-                    return 150;
-                }
-
-                if (block instanceof BlockLog) {
-                    return 1200;
-                }
-
-                if (block.getMaterial() == Material.wood) {
-                    return 300;
-                }
-
-                if (block == Blocks.coal_block) {
-                    return 16000;
-                }
-            }
-
-            if (item instanceof ItemTool && ((ItemTool) item).getToolMaterialName().equals("WOOD")) return 200;
-            if (item instanceof ItemSword && ((ItemSword) item).getToolMaterialName().equals("WOOD")) return 200;
-            if (item instanceof ItemHoe && ((ItemHoe) item).getToolMaterialName().equals("WOOD")) return 200;
-            if (item == Items.stick) return 100;
-            if (item == Items.coal) return 1600;
-            if (item == Items.lava_bucket) return 20000;
-            if (BlockUtils.getBlockFromItem(item) == Blocks.sapling) return 100;
-            if (item == Items.blaze_rod) return 2400;
-            return GameRegistry.getFuelValue(par0ItemStack);
-        }
-    }
-
-    /**
      * Return true if item is a fuel source (getItemBurnTime() > 0).
      */
     public static boolean isItemFuel(ItemStack par0ItemStack) {
-        return getFuelTime(par0ItemStack) > 0;
+        return TileEntityFurnace.getItemBurnTime(par0ItemStack) > 0;
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16603
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21133

The code used by Natura for burn time calculation is almost identical to the vanilla code.
The only difference is that it was not firing the FuelBurnTimeEvent which bop uses for the pile of ashes burn time. As the code would be identical if I added the event firing, I just called the vanilla method.
