### PR TITLE
Prevent Redwood from growing from a single sapling

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,13 +1,13 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:Mantle:0.5.0:dev")
+    api("com.github.GTNewHorizons:Mantle:0.5.1:dev")
 
-    compileOnly("com.github.GTNewHorizons:waila:1.8.8:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.6:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.37-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:waila:1.8.12:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.8:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.51-GTNH:dev") {transitive = false}
     compileOnly("curse.maven:minefactory-reloaded-66672:2366150") {transitive = false}
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false}
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.57-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.81-GTNH:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -151,7 +151,7 @@ modrinthProjectId =
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true.
 modrinthRelations =
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.42'
 }
 
 

--- a/src/main/java/mods/natura/blocks/trees/NSaplingBlock.java
+++ b/src/main/java/mods/natura/blocks/trees/NSaplingBlock.java
@@ -109,6 +109,33 @@ public class NSaplingBlock extends BlockSapling {
         else return EnumPlantType.Nether;
     }
 
+    private boolean canGrowRedwood(World world, int x, int y, int z) {
+        int numSaplings = 0;
+
+        for (int xPos = -3; xPos <= 3; xPos++) {
+            for (int zPos = -3; zPos <= 3; zPos++) {
+                int ecks = x + xPos, zee = z + zPos;
+                if (world.getBlock(x + xPos, y, z + zPos) == this
+                        && world.getBlockMetadata(x + xPos, y, z + zPos) % 8 == 0) {
+                    numSaplings++;
+                }
+            }
+        }
+
+        return numSaplings >= 40;
+    }
+
+    private void clearRedwoodGrowthArea(World world, int x, int y, int z) {
+        for (int xPos = -4; xPos <= 4; xPos++) {
+            for (int zPos = -4; zPos <= 4; zPos++) {
+                int ecks = x + xPos, zee = z + zPos;
+                if (world.getBlock(ecks, y, zee) == this && world.getBlockMetadata(ecks, y, zee) % 8 == 0) {
+                    world.setBlock(ecks, y, zee, Blocks.air, 0, 4);
+                }
+            }
+        }
+    }
+
     @Override
     public void updateTick(World world, int x, int y, int z, Random random) {
         if (world.isRemote) {
@@ -118,35 +145,10 @@ public class NSaplingBlock extends BlockSapling {
         if (md % 8 == 0) {
             if (world.getBlockLightValue(x, y + 1, z) >= 9 && random.nextInt(120) == 0) {
                 if ((md & 8) == 0) world.setBlockMetadataWithNotify(x, y, z, md | 8, 4);
-                else {
-                    int numSaplings = 0;
-                    for (int xPos = -3; xPos <= 3; xPos++) {
-                        for (int zPos = -3; zPos <= 3; zPos++) {
-                            int ecks = x + xPos, zee = z + zPos;
-                            if (world.getBlock(x + xPos, y, z + zPos) == this
-                                    && world.getBlockMetadata(x + xPos, y, z + zPos) % 8 == 0) {
-                                numSaplings++;
-                            }
-                        }
-                    }
-
-                    if (numSaplings >= 40) {
-                        for (int xPos = -4; xPos <= 4; xPos++) {
-                            for (int zPos = -4; zPos <= 4; zPos++) {
-                                int ecks = x + xPos, zee = z + zPos;
-                                if (world.getBlock(ecks, y, zee) == this
-                                        && world.getBlockMetadata(ecks, y, zee) % 8 == 0) {
-                                    world.setBlock(ecks, y, zee, Blocks.air, 0, 4);
-                                }
-                            }
-                        }
-                        func_149879_c(world, x, y, z, random);
-                    }
-                }
+                else func_149879_c(world, x, y, z, random);
             }
         } else if (md % 8 <= 3) {
-            if (random.nextInt(10) == 0 && world.getBlockLightValue(x, y + 1, z) >= 9) // && random.nextInt(120) == 0)
-            {
+            if (random.nextInt(10) == 0 && world.getBlockLightValue(x, y + 1, z) >= 9) {
                 if ((md & 8) == 0) world.setBlockMetadataWithNotify(x, y, z, md | 8, 4);
                 else func_149879_c(world, x, y, z, random);
             }
@@ -176,7 +178,6 @@ public class NSaplingBlock extends BlockSapling {
     public void func_149878_d(World world, int x, int y, int z, Random random) {
         if (!net.minecraftforge.event.terraingen.TerrainGen.saplingGrowTree(world, random, x, y, z)) return;
         int md = world.getBlockMetadata(x, y, z) % 8;
-        world.setBlock(x, y, z, Blocks.air);
         WorldGenerator obj = null;
 
         if (md == 1) obj = new EucalyptusTreeGenShort(0, 1);
@@ -186,8 +187,12 @@ public class NSaplingBlock extends BlockSapling {
         else if (md == 5) obj = new BloodTreeLargeGen(3, 2);
         else if (md == 6) obj = new DarkwoodGen(true, 3, 0);
         else if (md == 7) obj = new FusewoodGen(true, 3, 1);
-        else obj = new RedwoodTreeGen(true, NContent.redwood);
+        else if (canGrowRedwood(world, x, y, z)) {
+            clearRedwoodGrowthArea(world, x, y, z);
+            obj = new RedwoodTreeGen(true, NContent.redwood);
+        } else return;
 
+        world.setBlock(x, y, z, Blocks.air);
         if (!(obj.generate(world, random, x, y, z))) world.setBlock(x, y, z, this, md + 8, 3);
     }
 

--- a/src/main/java/mods/natura/blocks/trees/NSaplingBlock.java
+++ b/src/main/java/mods/natura/blocks/trees/NSaplingBlock.java
@@ -114,7 +114,6 @@ public class NSaplingBlock extends BlockSapling {
         if (world.isRemote) {
             return;
         }
-        super.updateTick(world, x, y, z, random);
         int md = world.getBlockMetadata(x, y, z);
         if (md % 8 == 0) {
             if (world.getBlockLightValue(x, y + 1, z) >= 9 && random.nextInt(120) == 0) {


### PR DESCRIPTION
This looks like a big oversight, but seems to have been there from the beginning:

Redwood trees were able to grow (randomly or using bone meal) from a single sapling, even though according to the tooltip they should require a patch of 7x7 saplings.

The first commit drops a call to `BlockSapling#updateTick()` which would  circumvent any growth criteria check and directly grow a Redwood from a single sapling (through `NSapling#func_149879_c`).

The second commit refactors the growth criteria check to also apply when bone mealing a sapling (which would call `NSapling#func_149878_d` directly).

If you want to grow your Redwoods now, you need to lay down a 7x7 field of saplings and bone meal or Watering Can one of the 9 saplings in the center of the field.

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21085